### PR TITLE
feat(main-deploy): improve deploy workflow with main branch support

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,8 +8,7 @@ on:
 
 jobs:
   # Build & deploy previews on PR open/update
-  build-and-deploy:
-    if: ${{ github.event.action != 'closed' }}
+  deploy-preview:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,9 @@ name: PR Preview for GitHub Pages
 on:
   pull_request:
     types: [opened, synchronize, reopened, closed]
+  push:
+    branches:
+      - main
 
 jobs:
   # Build & deploy previews on PR open/update
@@ -40,3 +43,30 @@ jobs:
         uses: rossjrw/pr-preview-action@v1
         with:
           source-dir: .vitepress/dist
+
+  deploy-main:
+    name: Deploy to GitHub Pages
+    runs-on: ubuntu-latest
+    if: ${{ github.ref == 'refs/heads/main' }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+          run_install: false
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install
+      - name: Build site
+        env:
+          VITE_BASE_URL: /docs-pr-preview
+        run: pnpm run docs:build
+      - name: Deploy to GitHub Pages
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: .vitepress/dist


### PR DESCRIPTION
## Summary of Changes

This pull request updates the GitHub Actions workflow for deployment. Key changes include:

- **Add deployment on push to main**: The workflow now triggers on push events to the `main` branch, enabling automatic deployment.
- **Refactor job names**: The `build-and-deploy` job is renamed to `deploy-preview` for clarity.
- **Add deploy-main job**: Introduces a new `deploy-main` job that builds and deploys the site to GitHub Pages when changes are pushed to `main`.
- **Update steps for deployment**:
  - Uses `pnpm/action-setup@v4` for pnpm setup.
  - Uses Node.js 22 and caches pnpm dependencies.
  - Installs dependencies and builds the site with `pnpm`.
  - Deploys to GitHub Pages using `JamesIves/github-pages-deploy-action@v4`.

These changes improve the CI/CD pipeline by supporting both preview deployments for PRs and production deployments for the main branch.
